### PR TITLE
Implement per-server bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -211,35 +211,24 @@ class MusicBot(discord.Client):
         if voice_channel is None:
             # Exit early if user is not connected
             return
-        media = None
 
-        video_metadata = None
+        media = None
         if self.url_regex.match(command_content):
             media = pafy.new(command_content)
         else:
             search_result = VideosSearch(command_content).result()
             media = pafy.new(search_result["result"][0]["id"])
 
-        voice_client = await self.connect_deaf(voice_channel)
-        if voice_client.is_playing():
-            await message.channel.send(
-                f"Added to Queue: \n```\n{video_metadata.title}\n```"
-            )
-        else:
-            await message.channel.send(
-                f"Now Playing: \n```\n{video_metadata.title}\n```"
-            )
-
-        logging.info("Pafy found %s", video_metadata)
-
         # We queue up a pair of the media metadata and the message context, so we can
         # continue to message the channel that this command was instanciated from as the
         # queue is unrolled.
         self.play_ctx_queue.put((media, message))
 
+        voice_client = await self.connect_deaf(voice_channel)
         if voice_client.is_playing():
-            await message.channel.send("Added to Queue: " + media.title)
+            await message.channel.send(f"Added to Queue: \n```\n{media.title}\n```")
         else:
+            await message.channel.send(f"Now Playing: \n```\n{media.title}\n```")
             self.next_in_queue(None)
 
     async def stop(self, message, _command_content):

--- a/bot.py
+++ b/bot.py
@@ -221,11 +221,11 @@ class MusicBot(discord.Client):
         voice_client = await voice_channel.connect_deaf()
         if voice_client.is_playing():
             await message.channel.send(
-                "Added to Queue: \n```\n{title}\n```".format(title=video_metadata.title)
+                f"Added to Queue: \n```\n{video_metadata.title}\n```"
             )
         else:
             await message.channel.send(
-                "Now Playing: \n```\n{title}\n```".format(title=video_metadata.title)
+                f"Now Playing: \n```\n{video_metadata.title}\n```"
             )
 
         logging.info("Pafy found %s", video_metadata)

--- a/bot.py
+++ b/bot.py
@@ -151,9 +151,10 @@ class MusicBot(discord.Client):
 
     def next_in_queue(self, _):
         """Switch to next song in queue"""
+        # FIXME Handle queues
         if not self.song_queue.empty():
             self.voice_client.stop()
-            self.voice_client.play(self.song_queue.get(), after=self.next_in_queue)
+            self.voice_client.play(self.song_queue.get())
 
     async def get_voice_channel(self, message):
         """
@@ -212,12 +213,10 @@ class MusicBot(discord.Client):
         audio_source = discord.FFmpegPCMAudio(audio_url)
 
         if voice_client.is_playing():
-            song_queue = self.get_song_queue(message)
+            song_queue = queue.Queue()  # FIXME handle queues
             song_queue.put(audio_source)
         else:
-            voice_client.play(
-                audio_source, after=MusicBot.QueueHandler(voice_client, message.guild)
-            )
+            voice_client.play(audio_source)
 
     async def stop(self, message, _command_content):
         """Stop currently playing song"""

--- a/bot.py
+++ b/bot.py
@@ -162,7 +162,9 @@ class MusicBot(discord.Client):
         """
         Get voice channel for message author. Complain if author is not in a channel
         """
-        assert isinstance(message, discord.Message)
+        if not isinstance(message, discord.Message):
+            logging.error("message is not of type discord.Message!")
+            return None
         if message.author.voice is None:
             await message.channel.send("You are not connected to a voice channel!")
             return None
@@ -174,15 +176,17 @@ class MusicBot(discord.Client):
         Get voice client for message author. Complain if author is not in a channel,
         connect to author voice client if not yet connected
         """
-        assert isinstance(message, discord.Message)
+        if not isinstance(message, discord.Message):
+            logging.error("message is not of type discord.Message!")
+            return None
         voice_channel = await self.get_voice_channel(message)
-        if voice_channel is not None:
-            for voice_client in self.voice_clients:
-                if voice_client.guild == message.guild:
-                    logging.info("Self in voice channel")
-                    return voice_client
-            return await self.connect_deaf(voice_channel)
-        return None
+        if voice_channel is None:
+            return None
+        for voice_client in self.voice_clients:
+            if voice_client.guild == message.guild:
+                logging.info("Self in voice channel")
+                return voice_client
+        return await self.connect_deaf(voice_channel)
 
     async def connect_deaf(self, channel):
         """Connect to channel self-deafened, the connected voice client"""


### PR DESCRIPTION
Make bot available to multiple servers simultaneously.

- Bot can play music in two channels in different servers at the same time
- Bot has different queues depending on server

----
**TODO**
- [x] ~Fix queues~
- [x] Merge with upstream

---
Queueing per guild is fixed by #18
Partial fix for #19 